### PR TITLE
(fix) Product pictures don't update

### DIFF
--- a/client/containers/similar-products.js
+++ b/client/containers/similar-products.js
@@ -1,5 +1,5 @@
 import { Meteor } from "meteor/meteor";
-import { registerComponent } from "@reactioncommerce/reaction-components";
+import { registerComponent, getHOCs } from "@reactioncommerce/reaction-components";
 import { composeWithTracker } from "/imports/plugins/core/components/lib";
 import { Tags, Products } from "/lib/collections";
 
@@ -19,11 +19,12 @@ function composer(props, onData) {
       }).fetch();
     }
     onData(null, {
+      ...props,
       products: similarProducts
     });
   }
 }
 
-registerComponent("SimilarProducts", SimilarProducts, composeWithTracker(composer));
+registerComponent("SimilarProducts", SimilarProducts, [...getHOCs("ProductDetail"), composeWithTracker(composer)]);
 
 export default composeWithTracker(composer)(SimilarProducts);

--- a/server/register.js
+++ b/server/register.js
@@ -9,7 +9,6 @@ function changeProductDetailPageLayout() {
     if (item.children) {
       for (const child of item.children) {
         if (child.component === "ProductMetadata") {
-          // Replace product metadata with our Google Maps component
           child.component = "SimilarProducts";
         }
       }


### PR DESCRIPTION
Closes #37 

Ensure that the PDP uses media subscription from core's detail page.
This is done through extending the SimilarProducts container with HOCs from core's PDP component.