### PR TITLE
Modified to work with Reaction 1.12.1

### DIFF
--- a/client/components/product-variant/customer/productGrid.js
+++ b/client/components/product-variant/customer/productGrid.js
@@ -71,7 +71,7 @@ class ProductGrid extends ProductGridCore {
         const insertAt = (products.length && Math.ceil(products.length / 2)) || 0;
         products.splice(insertAt, 0, { src: "/plugins/reaction-swag-shop/mountain-road.jpg" });
       }
-      const currentTag = ReactionProduct.getTag();
+      const currentTag = Reaction.getCurrentTag();
       return products.map((product, index) => {
         if (product.src) {
           return (

--- a/client/containers/product-variant/productsContainerCustomer.js
+++ b/client/containers/product-variant/productsContainerCustomer.js
@@ -47,7 +47,7 @@ function composer(props, onData) {
     return;
   }
 
-  const currentTag = ReactionProduct.getTag();
+  const currentTag = Reaction.getCurrentTag();
 
   const sort = {
     [`positions.${currentTag}.position`]: 1,


### PR DESCRIPTION
Reaction 1.12.1 throws  `ERROR: ReactionProduct.getTag() is not defined`